### PR TITLE
fix: use full path in resource name field for unique identification

### DIFF
--- a/src/mcp-transport.ts
+++ b/src/mcp-transport.ts
@@ -413,8 +413,8 @@ Please:
       // Convert storage objects to MCP resources
       const resources = objects.map((obj) => ({
         uri: `file:///${obj.key}`,
-        name: obj.key.split('/').pop() || obj.key,
-        title: obj.key,
+        name: obj.key, // Full path for unique identification
+        title: obj.key, // Full path shown in UI
         description: `Document in ${obj.key.split('/').slice(0, -1).join('/')}`,
         mimeType: obj.key.endsWith('.md') ? 'text/markdown' : 'text/plain',
         annotations: {
@@ -461,8 +461,8 @@ Please:
         contents: [
           {
             uri,
-            name: path.split('/').pop() || path,
-            title: path,
+            name: path, // Full path for unique identification
+            title: path, // Full path shown in UI
             mimeType: path.endsWith('.md') ? 'text/markdown' : 'text/plain',
             text: content,
             annotations: fileObj


### PR DESCRIPTION
Problem: Resources were using just the filename in the 'name' field (e.g., "README.md"), making files with the same name indistinguishable in Claude Desktop's resource picker. Multiple README.md files from different directories all appeared identical.

Solution: Use the full path as the 'name' field (e.g., "projects/app/README.md") to ensure each resource is uniquely identifiable.

Test-Driven Development approach:
1. Added failing tests demonstrating the problem:
   - Multiple README.md files were indistinguishable
   - Name field only contained filename, not full path
2. Fixed implementation in both handlers:
   - resources/list: Changed name from filename to full path
   - resources/read: Changed name from filename to full path
3. Updated existing test expectations
4. All 353 tests now passing (added 2 new tests)

Changes:
- src/mcp-transport.ts: Use obj.key directly for name field
- test/unit/mcp-resources.test.ts: Add tests + update expectations

This fixes the unusable resource picker in Claude Desktop where multiple files with the same name couldn't be differentiated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)