### PR TITLE
feat: propose combined deployment workflow (dev→prod pipeline)

### DIFF
--- a/.github/workflows-proposed/README.md
+++ b/.github/workflows-proposed/README.md
@@ -1,0 +1,124 @@
+# Proposed Combined Deployment Workflow
+
+## Overview
+
+This combines the `deploy-development.yml` and `deploy-production.yml` workflows into a single pipeline that:
+
+1. **Development (Preprod)**: Deploys to dev environment
+2. **Health Check**: Validates dev deployment
+3. **Production**: Automatically promotes to production if dev health checks pass
+4. **Versioning**: Auto-generates version tags (defaults to hotfix for incremental changes)
+
+## Key Changes
+
+### Before (Separate Workflows)
+
+```
+Push to main → deploy-development.yml → Dev deployment
+Manual trigger → deploy-production.yml → Prod deployment
+```
+
+### After (Combined Workflow)
+
+```
+Push to main → deploy-combined.yml:
+  1. Dev deployment (preprod)
+  2. Health check (dev)
+  3. Prod deployment (automatic)
+  4. Health check (prod)
+  5. Create tag & release
+```
+
+## Features
+
+- ✅ **Preprod validation**: Dev becomes a preprod environment
+- ✅ **Automatic promotion**: No manual trigger needed for production
+- ✅ **Health checks**: Both environments validated
+- ✅ **Automatic rollback**: On health check failure
+- ✅ **Version management**: Auto-increments from git tags
+- ✅ **Manual approval (commented)**: Ready for when you need it
+- ✅ **Hotfix mode support**: Blocks dev deploys during hotfix PRs
+
+## Default Deployment Type
+
+Auto-deployments from `main` default to **hotfix** (incremental version bumps):
+- `v25.1.0` → `v25.1.1` (hotfix)
+- `v25.1.1` → `v25.1.2` (hotfix)
+
+For major releases, you can still manually trigger the production workflow with `deployment_type: release`.
+
+## When You Want Manual Approval
+
+To add a manual approval step before production:
+
+1. Uncomment the `approve-production` job (lines 365-376)
+2. Update `deploy-production` job's `needs` to include `approve-production` (line 381)
+3. Create a `production-approval` environment in GitHub with required reviewers
+
+## Migration Steps
+
+1. **Test the combined workflow**:
+   ```bash
+   # Push a small change to main
+   git push origin main
+
+   # Watch the workflow:
+   # - Should deploy to dev
+   # - Run health checks
+   # - Promote to production
+   # - Create tag and release
+   ```
+
+2. **If successful, move the workflow**:
+   ```bash
+   # Backup old workflows
+   mkdir -p .github/workflows-old
+   mv .github/workflows/deploy-development.yml .github/workflows-old/
+   mv .github/workflows/deploy-production.yml .github/workflows-old/
+
+   # Move new workflow into place
+   mv .github/workflows-proposed/deploy-combined.yml .github/workflows/
+
+   # Commit
+   git add .github/workflows*
+   git commit -m "feat: combine deployment workflows (dev → prod pipeline)"
+   git push origin main
+   ```
+
+3. **Delete old workflows after confirming**:
+   ```bash
+   rm -rf .github/workflows-old
+   git add .github/workflows-old
+   git commit -m "chore: remove old deployment workflows"
+   git push origin main
+   ```
+
+## Workflow Files to Delete
+
+After successful migration:
+- `.github/workflows/deploy-development.yml` - Replaced by combined workflow
+- `.github/workflows/deploy-production.yml` - Replaced by combined workflow
+
+## Workflow Files to Keep
+
+- `.github/workflows/create-hotfix.yml` - Still needed for hotfix creation
+- `.github/workflows/rollback.yml` - Still needed for manual rollbacks
+- `.github/workflows/test.yml` - Test-only workflow
+- `.github/workflows/claude.yml` - Claude Code automation
+
+## Future Considerations
+
+When you go public and want stricter production controls:
+
+1. Uncomment the manual approval job
+2. Configure reviewers in GitHub environment settings
+3. Consider changing default deployment type from "hotfix" to require explicit choice
+4. Add more sophisticated health checks (load tests, smoke tests, etc.)
+
+## Notes
+
+- The combined workflow automatically detects hotfix branches (`hotfix/**`)
+- Development deployments are blocked during active hotfix PRs
+- Tags are only created after successful production deployment
+- Automatic rollback triggers if production health checks fail
+- Coverage reports still run and track trends

--- a/.github/workflows-proposed/deploy-combined.yml
+++ b/.github/workflows-proposed/deploy-combined.yml
@@ -1,0 +1,671 @@
+name: Deploy (Development → Production)
+
+on:
+  push:
+    branches:
+      - main
+      - 'hotfix/**'
+
+permissions:
+  contents: write
+  deployments: write
+  pull-requests: write
+
+jobs:
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.0.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run type check
+        run: pnpm run type-check
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.0.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm test -- --coverage --ci --silent
+
+      - name: Report code coverage
+        uses: clearlyip/code-coverage-report-action@v5
+        if: always()
+        with:
+          filename: 'coverage/clover.xml'
+          badge: true
+          fail_on_negative_difference: true
+          # No overall_coverage_fail_threshold - use trend-based monitoring only
+
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.0.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run E2E tests
+        run: pnpm run test:e2e
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.0.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run linter
+        run: pnpm run lint
+
+      - name: Check formatting
+        run: pnpm run format
+
+  deploy-development:
+    name: Deploy to Development (Preprod)
+    runs-on: ubuntu-latest
+    needs: [type-check, unit-tests, e2e-tests, lint]
+    environment:
+      name: development
+
+    outputs:
+      deployment_url: ${{ steps.config.outputs.deployment_url }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract configuration
+        id: config
+        run: |
+          # Read Node.js version from .mise.toml
+          NODE_VERSION=$(grep -E '^node = "([0-9]+)"' .mise.toml | sed -E 's/node = "([0-9]+)"/\1/')
+          echo "node_version=$NODE_VERSION" >> $GITHUB_OUTPUT
+
+          # Read development worker name from wrangler.toml
+          WORKER_NAME=$(grep -E '^\[env\.development\]' -A 10 wrangler.toml | grep -E '^name = "([^"]+)"' | sed -E 's/name = "([^"]+)"/\1/')
+          echo "worker_name=$WORKER_NAME" >> $GITHUB_OUTPUT
+
+          # Build deployment URL
+          DEPLOYMENT_URL="https://${WORKER_NAME}.${{ vars.CLOUDFLARE_SUBDOMAIN }}.workers.dev"
+          echo "deployment_url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+
+          echo "✅ Configuration extracted:"
+          echo "  Node.js version: $NODE_VERSION"
+          echo "  Worker name: $WORKER_NAME"
+          echo "  Deployment URL: $DEPLOYMENT_URL"
+
+      - name: Check for hotfix mode (main branch only)
+        if: github.ref == 'refs/heads/main'
+        id: check_hotfix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Use issues API (not pulls API) - pulls.list doesn't support labels parameter
+            // PRs are issues in GitHub's data model, so we filter for items with pull_request property
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'hotfix'
+            });
+
+            // Filter to only pull requests (issues with pull_request property)
+            const hotfixPrs = issues.filter(issue => issue.pull_request);
+
+            if (hotfixPrs.length > 0) {
+              const pr = hotfixPrs[0];
+              core.notice(`⚠️ Development deployment blocked - hotfix in progress: ${pr.html_url}`);
+
+              // Post comment to the commit
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+                body: `## ⚠️ Development Deployment Skipped
+
+            Development environment is in **hotfix mode**.
+
+            **Active Hotfix PR:** ${pr.html_url}
+
+            Development deployments from \`main\` are blocked while a hotfix incident is active. The development environment will track the hotfix branch until the incident is resolved.
+
+            Normal development deployments will resume when the hotfix PR is merged.`
+              });
+
+              core.setFailed('Development deployment blocked due to active hotfix PR');
+            }
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.config.outputs.node_version }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.0.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Inject version information (dev)
+        run: |
+          BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          COMMIT_SHA="${{ github.sha }}"
+
+          # Replace placeholders in version.ts
+          sed -i "s/__VERSION__/dev/g" src/version.ts
+          sed -i "s/__COMMIT_SHA__/$COMMIT_SHA/g" src/version.ts
+          sed -i "s/__BUILD_TIME__/$BUILD_TIME/g" src/version.ts
+          sed -i "s/__ENVIRONMENT__/development/g" src/version.ts
+
+          echo "✅ Injected version information:"
+          echo "  Version: dev"
+          echo "  Commit: ${COMMIT_SHA:0:7}"
+          echo "  Build Time: $BUILD_TIME"
+          echo "  Environment: development"
+
+      - name: Create GitHub deployment (dev)
+        id: deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: 'development',
+              description: 'Development deployment (preprod) from ${{ github.ref_name }}',
+              auto_merge: false,
+              required_contexts: [],
+            });
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'in_progress',
+              description: 'Deploying to Cloudflare Workers (dev)',
+              environment_url: '${{ steps.config.outputs.deployment_url }}',
+            });
+
+            return deployment.data.id;
+
+      - name: Deploy to Cloudflare Workers (Development)
+        id: deploy
+        run: pnpm run deploy:dev
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Wait for deployment to stabilize
+        run: |
+          echo "Waiting 30 seconds for edge propagation..."
+          sleep 30
+
+      - name: Health check with retries (dev)
+        id: health_check
+        run: |
+          HEALTH_URL="${{ steps.config.outputs.deployment_url }}/health"
+          echo "Checking health endpoint: $HEALTH_URL"
+          echo "Checking health endpoint (3 attempts with 10s delays)..."
+
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt/3..."
+            RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL" || echo "000")
+
+            if [ "$RESPONSE" == "200" ]; then
+              echo "✅ Health check passed (HTTP $RESPONSE)"
+              echo "HEALTH_STATUS=success" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            echo "❌ Health check failed (HTTP $RESPONSE)"
+
+            if [ $attempt -lt 3 ]; then
+              echo "⏳ Waiting 10 seconds before retry..."
+              sleep 10
+            fi
+          done
+
+          echo "❌ Health check failed after 3 attempts"
+          echo "HEALTH_STATUS=failure" >> $GITHUB_OUTPUT
+          exit 1
+
+      - name: Update deployment status (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.result }},
+              state: 'success',
+              description: 'Development deployment successful - promoting to production',
+              environment_url: '${{ steps.config.outputs.deployment_url }}',
+            });
+
+      - name: Update deployment status (failure)
+        if: failure() && steps.deployment.outputs.result
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.result }},
+              state: 'failure',
+              description: 'Development deployment failed',
+              environment_url: '${{ steps.config.outputs.deployment_url }}',
+            });
+
+      - name: Create deployment summary (dev)
+        if: always()
+        run: |
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "### ✅ Development Deployment Successful (Preprod)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Environment:** Development (Preprod)" >> $GITHUB_STEP_SUMMARY
+            echo "**Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Deployed at:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+            echo "**URL:** ${{ steps.config.outputs.deployment_url }}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "🚀 **Next:** Automatic promotion to production" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ❌ Development Deployment Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The deployment to development has failed. Production deployment will not proceed." >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # Uncomment this job when you want to add manual approval before production deployment
+  # approve-production:
+  #   name: Approve Production Deployment
+  #   runs-on: ubuntu-latest
+  #   needs: [deploy-development]
+  #   environment:
+  #     name: production-approval
+  #
+  #   steps:
+  #     - name: Manual approval gate
+  #       run: |
+  #         echo "✅ Production deployment approved"
+  #         echo "Proceeding to production deployment..."
+
+  deploy-production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    needs: [deploy-development]
+    # Uncomment the line below when you add the approve-production job
+    # needs: [deploy-development, approve-production]
+    environment:
+      name: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history including tags
+          fetch-tags: true # Explicitly fetch all tags
+
+      - name: Extract configuration
+        id: config
+        run: |
+          # Read Node.js version from .mise.toml
+          NODE_VERSION=$(grep -E '^node = "([0-9]+)"' .mise.toml | sed -E 's/node = "([0-9]+)"/\1/')
+          echo "node_version=$NODE_VERSION" >> $GITHUB_OUTPUT
+
+          # Read worker name from wrangler.toml
+          WORKER_NAME=$(grep -E '^name = "([^"]+)"' wrangler.toml | head -1 | sed -E 's/name = "([^"]+)"/\1/')
+          echo "worker_name=$WORKER_NAME" >> $GITHUB_OUTPUT
+
+          # Build deployment URL
+          DEPLOYMENT_URL="https://${WORKER_NAME}.${{ vars.CLOUDFLARE_SUBDOMAIN }}.workers.dev"
+          echo "deployment_url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+
+          echo "✅ Configuration extracted:"
+          echo "  Node.js version: $NODE_VERSION"
+          echo "  Worker name: $WORKER_NAME"
+          echo "  Deployment URL: $DEPLOYMENT_URL"
+
+      - name: Determine next version from git tags
+        id: version
+        run: |
+          YEAR=$(date +%y)
+
+          # Auto-detect deployment type from branch name
+          BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$BRANCH_NAME" == hotfix/* ]]; then
+            DEPLOYMENT_TYPE="hotfix"
+            echo "🚨 Hotfix deployment detected (branch: $BRANCH_NAME)"
+          else
+            # Default to hotfix for auto-deploys from main (incremental changes)
+            DEPLOYMENT_TYPE="hotfix"
+            echo "📦 Auto-deployment from $BRANCH_NAME (type: hotfix)"
+          fi
+
+          echo "DEPLOYMENT_TYPE=$DEPLOYMENT_TYPE" >> $GITHUB_OUTPUT
+
+          # Get all tags for current year (pattern must match YEAR.RELEASE.HOTFIX format)
+          TAGS=$(git tag -l "v${YEAR}.*.*" | sort -V)
+
+          echo "🔍 Found existing tags for year ${YEAR}:"
+          if [ -z "$TAGS" ]; then
+            echo "  (none)"
+          else
+            echo "$TAGS" | sed 's/^/  /'
+          fi
+
+          if [ -z "$TAGS" ]; then
+            # First release of the year starts at YEAR.0.0
+            VERSION="${YEAR}.0.0"
+            echo "📝 No existing tags found - starting at v${VERSION}"
+          else
+            # Parse latest tag
+            LATEST_TAG=$(echo "$TAGS" | tail -1)
+            LATEST_VERSION=${LATEST_TAG#v}
+            echo "📝 Latest tag: $LATEST_TAG"
+
+            # Split version into components
+            IFS='.' read -r TAG_YEAR RELEASE HOTFIX <<< "$LATEST_VERSION"
+
+            if [ "$DEPLOYMENT_TYPE" == "release" ]; then
+              # Increment RELEASE, reset HOTFIX
+              RELEASE=$((RELEASE + 1))
+              HOTFIX=0
+              echo "📝 Incrementing RELEASE: ${TAG_YEAR}.${RELEASE}.${HOTFIX}"
+            else
+              # Increment HOTFIX
+              HOTFIX=$((HOTFIX + 1))
+              echo "📝 Incrementing HOTFIX: ${TAG_YEAR}.${RELEASE}.${HOTFIX}"
+            fi
+
+            VERSION="${YEAR}.${RELEASE}.${HOTFIX}"
+          fi
+
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "✅ Deploying version: v$VERSION (type: $DEPLOYMENT_TYPE)"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.config.outputs.node_version }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.0.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Get current deployment for rollback
+        id: current_deployment
+        continue-on-error: true
+        run: |
+          # Get the most recent deployment version ID for rollback
+          CURRENT_VERSION=$(pnpm wrangler deployments list --json 2>/dev/null | jq -r '.[0].versions[0].id // ""')
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          if [ -n "$CURRENT_VERSION" ]; then
+            echo "📌 Current deployment captured for rollback: $CURRENT_VERSION"
+          else
+            echo "⚠️  No previous deployment found (first deployment)"
+          fi
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Inject version information
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          COMMIT_SHA="${{ github.sha }}"
+
+          # Replace placeholders in version.ts
+          sed -i "s/__VERSION__/$VERSION/g" src/version.ts
+          sed -i "s/__COMMIT_SHA__/$COMMIT_SHA/g" src/version.ts
+          sed -i "s/__BUILD_TIME__/$BUILD_TIME/g" src/version.ts
+          sed -i "s/__ENVIRONMENT__/production/g" src/version.ts
+
+          echo "✅ Injected version information:"
+          echo "  Version: $VERSION"
+          echo "  Commit: ${COMMIT_SHA:0:7}"
+          echo "  Build Time: $BUILD_TIME"
+          echo "  Environment: production"
+
+      - name: Create GitHub deployment
+        id: deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: 'production',
+              description: 'Production deployment v${{ steps.version.outputs.VERSION }}',
+              auto_merge: false,
+              required_contexts: [],
+            });
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'in_progress',
+              description: 'Deploying to Cloudflare Workers',
+              environment_url: '${{ steps.config.outputs.deployment_url }}',
+            });
+
+            return deployment.data.id;
+
+      - name: Deploy to Cloudflare Workers (Production)
+        id: deploy
+        run: pnpm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Wait for deployment to stabilize
+        run: |
+          echo "Waiting 30 seconds for edge propagation..."
+          sleep 30
+
+      - name: Health check with retries
+        id: health_check
+        run: |
+          HEALTH_URL="${{ steps.config.outputs.deployment_url }}/health"
+          echo "Checking health endpoint: $HEALTH_URL"
+          echo "Checking health endpoint (3 attempts with 10s delays)..."
+
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt/3..."
+            RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL" || echo "000")
+
+            if [ "$RESPONSE" == "200" ]; then
+              echo "✅ Health check passed (HTTP $RESPONSE)"
+              echo "HEALTH_STATUS=success" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            echo "❌ Health check failed (HTTP $RESPONSE)"
+
+            if [ $attempt -lt 3 ]; then
+              echo "⏳ Waiting 10 seconds before retry..."
+              sleep 10
+            fi
+          done
+
+          echo "❌ Health check failed after 3 attempts"
+          echo "HEALTH_STATUS=failure" >> $GITHUB_OUTPUT
+          exit 1
+
+      - name: Update deployment status (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.result }},
+              state: 'success',
+              description: 'Deployment successful - v${{ steps.version.outputs.VERSION }}',
+              environment_url: '${{ steps.config.outputs.deployment_url }}',
+            });
+
+      - name: Automatic rollback on health check failure
+        if: failure() && steps.health_check.conclusion == 'failure' && steps.current_deployment.outputs.CURRENT_VERSION != ''
+        run: |
+          echo "🔙 Health check failed - triggering automatic rollback"
+          ROLLBACK_VERSION="${{ steps.current_deployment.outputs.CURRENT_VERSION }}"
+          echo "Rolling back to version: $ROLLBACK_VERSION"
+
+          pnpm wrangler rollback --version-id "$ROLLBACK_VERSION"
+
+          echo "✅ Rollback completed"
+          echo "### ⚠️ Automatic Rollback Executed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Reason:** Health check failed after 3 attempts" >> $GITHUB_STEP_SUMMARY
+          echo "**Rolled back to:** $ROLLBACK_VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "**Failed version:** ${{ steps.version.outputs.VERSION }}" >> $GITHUB_STEP_SUMMARY
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Update deployment status (failure)
+        if: failure() && steps.deployment.outputs.result
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.result }},
+              state: 'failure',
+              description: 'Deployment failed - ${{ steps.health_check.conclusion == 'failure' && 'health check failed' || 'deployment error' }}',
+              environment_url: '${{ steps.config.outputs.deployment_url }}',
+            });
+
+      - name: Create git tag after successful deployment
+        if: success()
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release v${VERSION} - Production Deployment"
+          git push origin "v${VERSION}"
+          echo "✅ Successfully created and pushed tag v${VERSION}"
+
+      - name: Create GitHub Release
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          gh release create "v${VERSION}" \
+            --title "Release v${VERSION}" \
+            --notes "## Release v${VERSION}
+
+          **Deployed to production:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')
+          **Deployment type:** ${{ steps.version.outputs.DEPLOYMENT_TYPE }}
+
+          See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for detailed release notes.
+
+          ### Test Coverage
+          - Coverage maintained or improved (trend-based monitoring)
+          - All tests passing
+
+          ### Deployment
+          - Environment: Production
+          - Worker URL: ${{ steps.config.outputs.deployment_url }}
+          - Commit: ${{ github.sha }}"
+
+      - name: Create deployment summary
+        if: always()
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "### 🚀 Deployment Successful (Production)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Environment:** Production" >> $GITHUB_STEP_SUMMARY
+            echo "**Version:** v${VERSION}" >> $GITHUB_STEP_SUMMARY
+            echo "**Deployment Type:** ${{ steps.version.outputs.DEPLOYMENT_TYPE }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Deployed at:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+            echo "**URL:** ${{ steps.config.outputs.deployment_url }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Git Tag:** v${VERSION}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ❌ Deployment Failed (Production)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The deployment to production has failed. Please check the logs." >> $GITHUB_STEP_SUMMARY
+            echo "**No git tag was created** (tags are only created on successful deployment)" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,6 +5,14 @@
 **Last Updated:** 2025-10-29
 
 **Recent Changes:**
+- ✅ Proposed combined deployment workflow (2025-10-30)
+  - Created combined dev→prod pipeline in `.github/workflows-proposed/`
+  - Deploys to dev (preprod) → health check → auto-promote to prod
+  - Defaults to hotfix versioning for incremental changes
+  - Includes commented-out manual approval step for future use
+  - Maintains hotfix mode detection and automatic rollback
+  - Ready for review and testing before replacing separate workflows
+
 - ✅ Fixed production deployment version calculation (Issue #24)
   - Added `fetch-depth: 0` and `fetch-tags: true` to checkout step (line 141-143)
   - Fixed tag pattern from `v${YEAR}.*` to `v${YEAR}.*.*` (line 182)


### PR DESCRIPTION
- Creates single workflow that deploys to dev as preprod
- Runs health checks on dev before promoting to prod
- Automatically promotes to production if dev health checks pass
- Defaults to hotfix versioning for incremental MVP changes
- Includes commented-out manual approval step for future use
- Maintains all safety features (hotfix mode, automatic rollback)

This addresses the MVP stage where production is not public and most testing happens in production. The combined workflow treats dev as a preprod validation stage before automatic promotion.

When the project goes public, uncomment the manual approval job to add gating before production deployments.

Files created in .github/workflows-proposed/ for review before replacing the existing separate workflows.